### PR TITLE
feat: OPTIONS on api with check against allowed webhook hosts list

### DIFF
--- a/Equinor.Maintenance.API.EventEnhancer/ConfigSections/AzureAd.cs
+++ b/Equinor.Maintenance.API.EventEnhancer/ConfigSections/AzureAd.cs
@@ -2,9 +2,11 @@ using JetBrains.Annotations;
 
 namespace Equinor.Maintenance.API.EventEnhancer.ConfigSections;
 
-public class AzureConfig
+public class AzureAd
 {
     public string   ClientId              { get; [UsedImplicitly] set; } = "";
+    public string   TenantId              { get; [UsedImplicitly] set; } = "";
+    public string   Instance              { get; [UsedImplicitly] set; } = "";
     public string   ClientSecret          { get; [UsedImplicitly] set; } = "";
     public string[] AllowedWebHookOrigins { get; [UsedImplicitly] set; } = { };
 }

--- a/Equinor.Maintenance.API.EventEnhancer/ConfigSections/AzureConfig.cs
+++ b/Equinor.Maintenance.API.EventEnhancer/ConfigSections/AzureConfig.cs
@@ -1,9 +1,10 @@
+using JetBrains.Annotations;
+
 namespace Equinor.Maintenance.API.EventEnhancer.ConfigSections;
 
 public class AzureConfig
 {
-
-    public string? ClientId     { get; set; }
-    public string? ClientSecret { get; set; }
-    public string[]? AllowedWebHookOrigins { get; set; }
+    public string   ClientId              { get; [UsedImplicitly] set; } = "";
+    public string   ClientSecret          { get; [UsedImplicitly] set; } = "";
+    public string[] AllowedWebHookOrigins { get; [UsedImplicitly] set; } = { };
 }

--- a/Equinor.Maintenance.API.EventEnhancer/ConfigSections/AzureConfig.cs
+++ b/Equinor.Maintenance.API.EventEnhancer/ConfigSections/AzureConfig.cs
@@ -1,0 +1,9 @@
+namespace Equinor.Maintenance.API.EventEnhancer.ConfigSections;
+
+public class AzureConfig
+{
+
+    public string? ClientId     { get; set; }
+    public string? ClientSecret { get; set; }
+    public string[]? AllowedWebHookOrigins { get; set; }
+}

--- a/Equinor.Maintenance.API.EventEnhancer/Equinor.Maintenance.API.EventEnhancer.csproj
+++ b/Equinor.Maintenance.API.EventEnhancer/Equinor.Maintenance.API.EventEnhancer.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.2.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
   </ItemGroup>
 

--- a/Equinor.Maintenance.API.EventEnhancer/Equinor.Maintenance.API.EventEnhancer.csproj
+++ b/Equinor.Maintenance.API.EventEnhancer/Equinor.Maintenance.API.EventEnhancer.csproj
@@ -4,11 +4,13 @@
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>7f10118a-6e9f-4ad1-9af0-9498a4d0afc8</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.2.1" />
     <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="1.25.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
   </ItemGroup>
 

--- a/Equinor.Maintenance.API.EventEnhancer/Equinor.Maintenance.API.EventEnhancer.csproj
+++ b/Equinor.Maintenance.API.EventEnhancer/Equinor.Maintenance.API.EventEnhancer.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.2.1" />
+    <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
   </ItemGroup>
 

--- a/Equinor.Maintenance.API.EventEnhancer/Logging/HttpContextEnricher.cs
+++ b/Equinor.Maintenance.API.EventEnhancer/Logging/HttpContextEnricher.cs
@@ -1,0 +1,22 @@
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Equinor.Maintenance.API.EventEnhancer.Logging;
+
+public class HttpContextEnricher : ILogEventEnricher
+{
+    private readonly IHttpContextAccessor _accessor;
+
+    public HttpContextEnricher(IHttpContextAccessor accessor) { _accessor = accessor; }
+
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+    {
+        if (_accessor.HttpContext == null)
+        {
+            return;
+        }
+
+        var user = _accessor.HttpContext.User.FindFirst("name") ?? _accessor.HttpContext.User.FindFirst("appid");
+        if (user is { }) logEvent.AddOrUpdateProperty(propertyFactory.CreateProperty("User", user.Value));
+    }
+}

--- a/Equinor.Maintenance.API.EventEnhancer/Program.cs
+++ b/Equinor.Maintenance.API.EventEnhancer/Program.cs
@@ -1,33 +1,50 @@
 using System.Net.Mime;
 using Equinor.Maintenance.API.EventEnhancer.ConfigSections;
+using Equinor.Maintenance.API.EventEnhancer.Logging;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
+using Microsoft.Identity.Web;
 using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
-builder.Host.UseSerilog((ctx, lc) => lc
-                                     .WriteTo.Console());
+builder.Services.AddTransient<HttpContextEnricher>();
+builder.Services.AddHttpContextAccessor();
+builder.Host.UseSerilog((_, services, lc) =>
+                        {
+                            lc
+                                .Enrich.FromLogContext()
+                                .Enrich.With(services.GetService<HttpContextEnricher>())
+                              .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} by user {User}{NewLine}{Exception}");
+                        });
 
-builder.Services.AddOptions<AzureConfig>()
-       .Bind(builder.Configuration.GetSection(nameof(AzureConfig)))
+builder.Services.AddOptions<AzureAd>()
+       .Bind(builder.Configuration.GetSection(nameof(AzureAd)))
        .Validate(config => config.AllowedWebHookOrigins.Any(), "AzureConfig:AllowedWebHookOrigins must be populated")
        .Validate(config => !string.IsNullOrWhiteSpace(config.ClientId), "AzureConfig:ClientId must be populated")
        .Validate(config => !string.IsNullOrWhiteSpace(config.ClientSecret), "AzureConfig:ClientSecret must be populated")
        .ValidateOnStart();
+
+
+builder.Services
+       .AddMicrosoftIdentityWebApiAuthentication(builder.Configuration, 
+                                                 subscribeToJwtBearerMiddlewareDiagnosticsEvents:builder.Environment.IsDevelopment());
 
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
 app.UseHttpsRedirection();
 
+app.UseAuthentication();
+app.UseAuthorization();
+
 app.MapGet("/", () => new OkObjectResult("Hello from Mini Api"))
 .WithName("HelloApi");
 
 app.MapMethods("/", new []{"OPTIONS"},
-               (IOptions<AzureConfig> azureConfig, HttpContext ctx) =>
+               (IOptions<AzureAd> azureConfig, HttpContext ctx) =>
                {
                    ctx.Response.StatusCode = StatusCodes.Status403Forbidden; //forbidden makes more sense than 405
 
@@ -42,6 +59,7 @@ app.MapMethods("/", new []{"OPTIONS"},
 
                    return Task.CompletedTask;
                })
-   .WithName("WebHookOptions");
+   .WithName("WebHookOptions")
+   .RequireAuthorization();
 
 app.Run();

--- a/Equinor.Maintenance.API.EventEnhancer/Program.cs
+++ b/Equinor.Maintenance.API.EventEnhancer/Program.cs
@@ -1,4 +1,8 @@
+using System.Net.Mime;
+using Equinor.Maintenance.API.EventEnhancer.ConfigSections;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -7,6 +11,13 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Host.UseSerilog((ctx, lc) => lc
                                      .WriteTo.Console());
 
+builder.Services.AddOptions<AzureConfig>()
+       .Configure(_ => builder.Configuration.GetSection(nameof(AzureConfig)))
+       .Validate(config => config.AllowedWebHookOrigins is not null && config.AllowedWebHookOrigins.Any(), "AzureConfig:AllowedWebHookOrigins must be populated")
+       .Validate(config => string.IsNullOrWhiteSpace(config.ClientId), "AzureConfig:ClientId must be populated")
+       .Validate(config => string.IsNullOrWhiteSpace(config.ClientSecret), "AzureConfig:ClientSecret must be populated")
+       .ValidateOnStart();
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
@@ -14,5 +25,24 @@ app.UseHttpsRedirection();
 
 app.MapGet("/", () => new OkObjectResult("Hello from Mini Api"))
 .WithName("HelloApi");
+
+app.MapMethods("/", new []{"OPTIONS"},
+               (IOptions<AzureConfig> azureConfig, HttpContext ctx) =>
+               {
+                   ctx.Response.StatusCode = StatusCodes.Status403Forbidden; //forbidden makes more sense than 405
+
+                   if (!ctx.Request.Headers.TryGetValue("WebHook-Request-Origin", out var webHookOrigin)
+                       || azureConfig.Value.AllowedWebHookOrigins is not null 
+                       && !azureConfig.Value.AllowedWebHookOrigins.Contains(webHookOrigin.ToString())) return Task.CompletedTask;
+                   
+                   
+                   ctx.Response.Headers.Allow       = new StringValues("GET");
+                   ctx.Response.Headers.ContentType = new StringValues(MediaTypeNames.Application.Json);
+                   ctx.Response.StatusCode          = StatusCodes.Status200OK;
+                   ctx.Response.Headers.TryAdd("WebHook-Allowed-Origin", webHookOrigin);
+
+                   return Task.CompletedTask;
+               })
+   .WithName("WebHookOptions");
 
 app.Run();

--- a/Equinor.Maintenance.API.EventEnhancer/appsettings.json
+++ b/Equinor.Maintenance.API.EventEnhancer/appsettings.json
@@ -5,7 +5,9 @@
     }
   },
   "AllowedHosts": "*",
-  "AzureConfig":{
+  "AzureAd": {
+    "TenantId": "3aa4a235-b6e2-48d5-9195-7fcf05b459b0",
+    "Instance": "https://login.microsoftonline.com/",
     "ClientId": "",
     "ClientSecret": "",
     "AllowedWebHookOrigins": []

--- a/Equinor.Maintenance.API.EventEnhancer/appsettings.json
+++ b/Equinor.Maintenance.API.EventEnhancer/appsettings.json
@@ -4,5 +4,10 @@
       "Default": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "AzureConfig":{
+    "ClientId": "",
+    "ClientSecret": "",
+    "AllowedWebHookOrigins": []
+  }
 }


### PR DESCRIPTION
AB#240388

Options endpoint implemented in minimal API. Expect there will be some changes here once OAS is defined, but at least a version is now implemented. 

API still is missing authorization. Should probably set up a keyvault with secrets and add auth next