### PR TITLE
feat: RestSharp implementation of MaintenanceApi

### DIFF
--- a/Equinor.Maintenance.API.EventEnhancer/Equinor.Maintenance.API.EventEnhancer.csproj
+++ b/Equinor.Maintenance.API.EventEnhancer/Equinor.Maintenance.API.EventEnhancer.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.4.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="1.25.1" />
+    <PackageReference Include="RestSharp" Version="108.0.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
   </ItemGroup>
@@ -40,7 +41,6 @@
     <Folder Include="..\.github\.idea\.idea..github.dir\.idea">
       <Link>.github\.idea\.idea..github.dir\.idea</Link>
     </Folder>
-    <Folder Include="MaintenanceApiClient" />
   </ItemGroup>
 
 </Project>

--- a/Equinor.Maintenance.API.EventEnhancer/MaintenanceApi/MaintenanceApiClient.cs
+++ b/Equinor.Maintenance.API.EventEnhancer/MaintenanceApi/MaintenanceApiClient.cs
@@ -1,0 +1,76 @@
+using System.Text.Json.Nodes;
+using Equinor.Maintenance.API.EventEnhancer.ConfigSections;
+using Microsoft.Identity.Web;
+using RestSharp;
+using RestSharp.Authenticators;
+
+namespace Equinor.Maintenance.API.EventEnhancer.MaintenanceApi;
+
+public class MaintenanceApiClient
+{
+    private readonly RestClient _restClient;
+
+    public MaintenanceApiClient(ITokenAcquisition tokenAcquisition, IConfiguration config)
+    {
+        _restClient
+            = new RestClient(new RestClientOptions(new Uri(config.GetConnectionString(nameof(ConnectionStrings.MaintenanceApi))))
+                             {
+                                 FollowRedirects = false
+                             })
+              .AddDefaultQueryParameter("api-version", "v1")
+              .UseJson();
+
+        _restClient.Authenticator = new MaintenanceApiCertificateAuthenticatior(tokenAcquisition, $"{config["MaintenanceApiClientId"]}/.default");
+    }
+
+    public async Task<RestResponse<JsonObject>> LookupFailureReport(string recordId, CancellationToken ct)
+    {
+        var message = new RestRequest($"maintenance-records/failure-reports/{recordId}")
+                      .AddQueryParameter("include-attachments", "true")
+                      .AddQueryParameter("include-status-details", "true")
+                      .AddQueryParameter("include-created-by-details", "false")
+                      .AddQueryParameter("include-activities", "true")
+                      .AddQueryParameter("include-tag-details", "true")
+                      .AddQueryParameter("include-tasks", "true")
+                      .AddQueryParameter("include-additional-metadata", "true");
+
+        return await _restClient.ExecuteAsync<JsonObject>(message, cancellationToken: ct);
+    }
+
+    public async Task<RestResponse<JsonObject>> LookupCorrectiveWorkOrder(string workOrderId, CancellationToken ct)
+    {
+        var message = new RestRequest($"work-orders/corrective-work-order/{workOrderId}")
+                      .AddQueryParameter("include-attachments", "true")
+                      .AddQueryParameter("include-status-details", "true")
+                      .AddQueryParameter("include-maintenance-records", "true")
+                      .AddQueryParameter("include-tag-details", "true")
+                      .AddQueryParameter("include-technical-feedback", "true")
+                      .AddQueryParameter("include-operations", "true")
+                      .AddQueryParameter("include-materials", "true")
+                      .AddQueryParameter("include-related-tags", "true");
+
+        return await _restClient.ExecuteAsync<JsonObject>(message, cancellationToken: ct);
+    }
+
+    public async Task<RestResponse<JsonObject>> FollowRedirect(string resource, CancellationToken ct)
+    {
+        var message = new RestRequest(resource);
+
+        return await _restClient.ExecuteAsync<JsonObject>(message, cancellationToken: ct);
+    }
+}
+
+public class MaintenanceApiCertificateAuthenticatior : AuthenticatorBase
+{
+    private readonly ITokenAcquisition _tokenAcquisition;
+    private readonly string _scope;
+
+    public MaintenanceApiCertificateAuthenticatior(ITokenAcquisition tokenAcquisition, string scope) : base("")
+    {
+        _tokenAcquisition = tokenAcquisition;
+        _scope            = scope;
+    }
+
+    protected override async ValueTask<Parameter> GetAuthenticationParameter(string accessToken)
+        => new HeaderParameter(KnownHeaders.Authorization, $"Bearer {await _tokenAcquisition.GetAccessTokenForAppAsync(_scope)}"); //tokenaqcuistion has caching
+}

--- a/Equinor.Maintenance.API.EventEnhancer/MaintenanceApi/Requests/MaintenanceRecordsBuilder.cs
+++ b/Equinor.Maintenance.API.EventEnhancer/MaintenanceApi/Requests/MaintenanceRecordsBuilder.cs
@@ -1,6 +1,6 @@
 using Microsoft.AspNetCore.WebUtilities;
 
-namespace Equinor.Maintenance.API.EventEnhancer.MaintenanceApiClient.Requests;
+namespace Equinor.Maintenance.API.EventEnhancer.MaintenanceApi.Requests;
 
 public class MaintenanceRecordsBuilder
 {

--- a/Equinor.Maintenance.API.EventEnhancer/MaintenanceApi/Requests/WorkorderBuilder.cs
+++ b/Equinor.Maintenance.API.EventEnhancer/MaintenanceApi/Requests/WorkorderBuilder.cs
@@ -1,6 +1,6 @@
 using Microsoft.AspNetCore.WebUtilities;
 
-namespace Equinor.Maintenance.API.EventEnhancer.MaintenanceApiClient.Requests;
+namespace Equinor.Maintenance.API.EventEnhancer.MaintenanceApi.Requests;
 
 public class WorkorderBuilder
 {

--- a/Equinor.Maintenance.API.EventEnhancer/Program.cs
+++ b/Equinor.Maintenance.API.EventEnhancer/Program.cs
@@ -4,6 +4,7 @@ using Azure.Identity;
 using Equinor.Maintenance.API.EventEnhancer.ConfigSections;
 using Equinor.Maintenance.API.EventEnhancer.Constants;
 using Equinor.Maintenance.API.EventEnhancer.Handlers;
+using Equinor.Maintenance.API.EventEnhancer.MaintenanceApi;
 using Equinor.Maintenance.API.EventEnhancer.Middlewares;
 using Equinor.Maintenance.API.EventEnhancer.Models;
 using MediatR;
@@ -76,7 +77,7 @@ services.AddMicrosoftIdentityWebApiAuthentication(config,
 services.AddHttpClient(Names.MainteanceApi,
                        cli => cli.BaseAddress = new Uri(config.GetConnectionString(nameof(ConnectionStrings.MaintenanceApi))))
         .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler { AllowAutoRedirect = false });
-
+services.AddScoped<MaintenanceApiClient>();
 services.AddAuthorization(opts =>
                           {
                               opts.AddPolicy(Policy.Publish,


### PR DESCRIPTION
Implemented http client with RestSharp library **as an evaluation**.

In my opinion, while a nice library with some nice patterns, it doesn't give us much, as it essentially is just a wrapper around httpclient and httpclienthandler. As always with using wrapper libraries, one loses control of the underlying settings (I did not find a way to explicitly turn of the cookie handling, have to write my small own httpclienthandler for that it seems). 

I had a small thought that this could be used in Maintenance API, for implementation of a SapClient, implementing a SapAuthenticator, but I don't think it will give us so much benefit, it will "kosta mer mer än det smakar"

WDYT?