### PR TITLE
Maintenance records comes from BUS2038 not from BUS2078

### DIFF
--- a/Equinor.Maintenance.API.EventEnhancer/Handlers/PublishMaintenanceEvent.cs
+++ b/Equinor.Maintenance.API.EventEnhancer/Handlers/PublishMaintenanceEvent.cs
@@ -60,7 +60,7 @@ public class PublishMaintenanceEvent : IRequestHandler<PublishMaintenanceEventQu
         var request = data switch
                       {
                           (_, "BUS2007", _) => WorkorderBuilder.BuildCorrectiveLookup(objectId),
-                          (_, "BUS2078", _) => MaintenanceRecordsBuilder.BuildFailureReportLookup(objectId),
+                          (_, "BUS2038", _) => MaintenanceRecordsBuilder.BuildFailureReportLookup(objectId),
                           _                 => throw new ArgumentOutOfRangeException(nameof(data))
                       };
         var tokenHeader2 = new AuthenticationHeaderValue(Microsoft.Identity.Web.Constants.Bearer,  (await tokenAwaitable2).AccessToken);


### PR DESCRIPTION
After debugging in SAP, I see the event triggered when a maintenance record is created is BUS2038.

Have adjusted in SAP, now need to adjust in Event Enhancer